### PR TITLE
Fix precache searches

### DIFF
--- a/src/Search.jsx
+++ b/src/Search.jsx
@@ -110,12 +110,14 @@ class Precache extends React.PureComponent {
     }
 
     cacheQueries(queries) {
-        const query = queries.shift();
-        this.serverRequest = $.get(
-            this.API + '/songs/search',
-            {q: query},
-            () => this.cacheQueries(queries)
-        )
+        if (queries.length) {
+            const query = queries.shift();
+            this.serverRequest = $.get(
+                this.API + '/songs/search',
+                {q: query}
+            )
+                .always(() => this.cacheQueries(queries));
+        }
     }
 
     render() {


### PR DESCRIPTION
- Explicitly terminate recursion
- Recurse within `.always` callback (rather than `success` callback) to
  keep going even after query with no results
