### PR TITLE
Link titles

### DIFF
--- a/src/Search.jsx
+++ b/src/Search.jsx
@@ -307,12 +307,14 @@ class Result extends React.PureComponent {
         const style = {textDecoration: this.props.selected ? 'underline' : null};
         const {artist, song} = this.props.result;
         const html = `${artist} &mdash; ${song}`;
+        const title = html.htmlToText();
         return (
             <li>
                 <Link
                     to={this.target}
                     style={style}
                     dangerouslySetInnerHTML={{__html: html}}
+                    title={title}
                 />
             </li>
         );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -40,6 +40,13 @@ String.prototype.trimAll = function () {
     return s;
 };
 
+String.prototype.htmlToText = function() {
+    const s = this.replace(/<[a-z]*>/ig, '')    // HTML open tags
+        .replace(/<\/[a-z]*>/ig, '')            // HTML close tags
+        .replace(/\&mdash;/ig, '-');
+    return s;
+}
+
 Array.prototype.choice = function () {
     return this[Math.floor(Math.random() * this.length)];
 };


### PR DESCRIPTION
Some artist names + song names are too long to fit on a single line, so we truncate them.  These titles help, because you can mouse-over the songs and see their full artist names + song names.
